### PR TITLE
Fix circular dependency between CommandHandlerResolver and EventBus

### DIFF
--- a/packages/cqrs/README.md
+++ b/packages/cqrs/README.md
@@ -109,12 +109,12 @@ use App\Queries\GetUserById;
 use Ody\CQRS\Attributes\CommandHandler;
 use Ody\CQRS\Attributes\EventHandler;
 use Ody\CQRS\Attributes\QueryHandler;
-use Ody\CQRS\Interfaces\EventBus;
+use Ody\CQRS\Interfaces\EventBusInterface;
 
 class UserService
 {
     #[CommandHandler]
-    public function createUser(CreateUserCommand $command, EventBus $eventBus)
+    public function createUser(CreateUserCommand $command, EventBusInterface $eventBus)
     {
         $user = User::create([
             'name' => $command->getName(),
@@ -147,16 +147,16 @@ namespace App\Controllers;
 
 use App\Commands\CreateUserCommand;
 use App\Queries\GetUserById;
-use Ody\CQRS\Interfaces\CommandBus;
-use Ody\CQRS\Interfaces\QueryBus;
+use Ody\CQRS\Interfaces\CommandBusInterface;
+use Ody\CQRS\Interfaces\QueryBusInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class UserController
 {
     public function __construct(
-        private readonly CommandBus $commandBus,
-        private readonly QueryBus   $queryBus
+        private readonly CommandBusInterface $commandBus,
+        private readonly QueryBusInterface   $queryBus
     ) {}
 
     public function createUser(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface

--- a/packages/cqrs/src/Api/CqrsApiAdapter.php
+++ b/packages/cqrs/src/Api/CqrsApiAdapter.php
@@ -2,8 +2,8 @@
 
 namespace Ody\CQRS\Api;
 
-use Ody\CQRS\Interfaces\CommandBus;
-use Ody\CQRS\Interfaces\QueryBus;
+use Ody\CQRS\Interfaces\CommandBusInterface;
+use Ody\CQRS\Interfaces\QueryBusInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -12,12 +12,12 @@ use Psr\Http\Message\ServerRequestInterface;
 class CqrsApiAdapter
 {
     /**
-     * @param CommandBus $commandBus
-     * @param QueryBus $queryBus
+     * @param CommandBusInterface $commandBus
+     * @param QueryBusInterface $queryBus
      */
     public function __construct(
-        protected readonly CommandBus $commandBus,
-        protected readonly QueryBus   $queryBus
+        protected readonly CommandBusInterface $commandBus,
+        protected readonly QueryBusInterface   $queryBus
     )
     {
     }

--- a/packages/cqrs/src/Api/example.php
+++ b/packages/cqrs/src/Api/example.php
@@ -12,8 +12,8 @@ use Ody\CQRS\Api\Documentation\ApiEndpoint;
 use Ody\CQRS\Api\Middleware\RequestMappingConfigFactory;
 use Ody\CQRS\Api\Middleware\RequestMappingMiddleware;
 use Ody\CQRS\Api\Middleware\ResponseFormattingMiddleware;
-use Ody\CQRS\Interfaces\CommandBus;
-use Ody\CQRS\Interfaces\QueryBus;
+use Ody\CQRS\Interfaces\CommandBusInterface;
+use Ody\CQRS\Interfaces\QueryBusInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -107,9 +107,9 @@ class UserController extends CqrsController
 class ApiSetupExample
 {
     public function setupMiddleware(
-        CommandBus        $commandBus,
-        QueryBus          $queryBus,
-        ResponseInterface $response
+        CommandBusInterface $commandBus,
+        QueryBusInterface   $queryBus,
+        ResponseInterface   $response
     ): array
     {
         // Create the CQRS adapter
@@ -136,8 +136,8 @@ class ApiSetupExample
      * Example of how to generate OpenAPI documentation
      */
     public function generateApiDocs(
-        CommandBus $commandBus,
-        QueryBus   $queryBus
+        CommandBusInterface $commandBus,
+        QueryBusInterface   $queryBus
     ): string
     {
         $generator = new \Ody\CQRS\Api\Documentation\OpenApiGenerator(

--- a/packages/cqrs/src/Bus/CommandBus.php
+++ b/packages/cqrs/src/Bus/CommandBus.php
@@ -6,8 +6,9 @@ use Ody\CQRS\Exception\CommandHandlerException;
 use Ody\CQRS\Exception\HandlerNotFoundException;
 use Ody\CQRS\Handler\Registry\CommandHandlerRegistry;
 use Ody\CQRS\Handler\Resolver\CommandHandlerResolver;
-use Ody\CQRS\Interfaces\CommandBus as CommandBusInterface;
+use Ody\CQRS\Interfaces\CommandBusInterface;
 use Ody\CQRS\Middleware\MiddlewareProcessor;
+use Throwable;
 
 class CommandBus implements CommandBusInterface
 {
@@ -47,7 +48,7 @@ class CommandBus implements CommandBusInterface
      * @param object $command
      * @return void
      * @throws HandlerNotFoundException
-     * @throws CommandHandlerException
+     * @throws CommandHandlerException|Throwable
      */
     public function dispatch(object $command): void
     {
@@ -71,12 +72,10 @@ class CommandBus implements CommandBusInterface
                     'executeHandler',
                     [$command, $handlerInfo],
                     function ($args) {
-                        return $this->executeHandler(...$args);
+                        $this->executeHandler(...$args);
                     }
                 );
-            } catch (CommandHandlerException $e) {
-                throw $e;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 throw new CommandHandlerException(
                     sprintf('Error handling command %s: %s', $commandClass, $e->getMessage()),
                     0,
@@ -95,14 +94,14 @@ class CommandBus implements CommandBusInterface
      * @param object $command The command to handle
      * @param array $handlerInfo The handler information
      * @return void
-     * @throws \Throwable
+     * @throws Throwable
      */
     public function executeHandler(object $command, array $handlerInfo): void
     {
         try {
             $handler = $this->handlerResolver->resolveHandler($handlerInfo);
             $handler($command);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             throw $e;
         }
     }

--- a/packages/cqrs/src/Bus/EventBus.php
+++ b/packages/cqrs/src/Bus/EventBus.php
@@ -4,7 +4,7 @@ namespace Ody\CQRS\Bus;
 
 use Ody\Container\Container;
 use Ody\CQRS\Handler\Registry\EventHandlerRegistry;
-use Ody\CQRS\Interfaces\EventBus as EventBusInterface;
+use Ody\CQRS\Interfaces\EventBusInterface;
 use Ody\CQRS\Middleware\MiddlewareProcessor;
 
 class EventBus implements EventBusInterface

--- a/packages/cqrs/src/Bus/QueryBus.php
+++ b/packages/cqrs/src/Bus/QueryBus.php
@@ -6,7 +6,7 @@ use Ody\CQRS\Exception\HandlerNotFoundException;
 use Ody\CQRS\Exception\QueryHandlerException;
 use Ody\CQRS\Handler\Registry\QueryHandlerRegistry;
 use Ody\CQRS\Handler\Resolver\QueryHandlerResolver;
-use Ody\CQRS\Interfaces\QueryBus as QueryBusInterface;
+use Ody\CQRS\Interfaces\QueryBusInterface as QueryBusInterface;
 use Ody\CQRS\Middleware\MiddlewareProcessor;
 
 class QueryBus implements QueryBusInterface

--- a/packages/cqrs/src/Handler/Resolver/CommandHandlerResolver.php
+++ b/packages/cqrs/src/Handler/Resolver/CommandHandlerResolver.php
@@ -3,17 +3,15 @@
 namespace Ody\CQRS\Handler\Resolver;
 
 use Ody\Container\Container;
-use Ody\CQRS\Interfaces\EventBus;
+use Ody\CQRS\Interfaces\EventBusInterface;
 
 class CommandHandlerResolver extends HandlerResolver
 {
     /**
      * @param Container $container
-     * @param EventBus|null $eventBus
      */
     public function __construct(
-        Container         $container,
-        private ?EventBus $eventBus = null
+        Container $container
     )
     {
         parent::__construct($container);
@@ -39,13 +37,13 @@ class CommandHandlerResolver extends HandlerResolver
 
         $expectsEventBus = count($parameters) > 1 &&
             $parameters[1]->getType() &&
-            is_a(EventBus::class, $parameters[1]->getType()->getName(), true);
+            is_a(EventBusInterface::class, $parameters[1]->getType()->getName(), true);
 
         if ($expectsEventBus) {
             return function ($command) use ($handler, $handlerMethod) {
                 // Get the EventBus lazily from the container when needed
-//                $eventBus = $this->container->make(EventBus::class);
-                return $handler->$handlerMethod($command, $this->eventBus);
+                $eventBus = $this->container->make(EventBusInterface::class);
+                return $handler->$handlerMethod($command, $eventBus);
             };
         }
 

--- a/packages/cqrs/src/Interfaces/CommandBusInterface.php
+++ b/packages/cqrs/src/Interfaces/CommandBusInterface.php
@@ -4,7 +4,7 @@ namespace Ody\CQRS\Interfaces;
 
 use Ody\CQRS\Handler\Registry\CommandHandlerRegistry;
 
-interface CommandBus
+interface CommandBusInterface
 {
     public function dispatch(object $command): void;
 

--- a/packages/cqrs/src/Interfaces/EventBusInterface.php
+++ b/packages/cqrs/src/Interfaces/EventBusInterface.php
@@ -2,7 +2,7 @@
 
 namespace Ody\CQRS\Interfaces;
 
-interface EventBus
+interface EventBusInterface
 {
     public function publish(object $event): void;
 }

--- a/packages/cqrs/src/Interfaces/QueryBusInterface.php
+++ b/packages/cqrs/src/Interfaces/QueryBusInterface.php
@@ -4,7 +4,7 @@ namespace Ody\CQRS\Interfaces;
 
 use Ody\CQRS\Handler\Registry\QueryHandlerRegistry;
 
-interface QueryBus
+interface QueryBusInterface
 {
     public function dispatch(object $query): mixed;
 


### PR DESCRIPTION
- Remove placeholder EventBus implementation in favor of proper dependency resolution order
- Fix "Target [EventBusInterface] is not instantiable" error in command handlers